### PR TITLE
lombokと同時に利用するとコンパイルエラーになる問題を修正

### DIFF
--- a/processor/processor.gradle
+++ b/processor/processor.gradle
@@ -10,4 +10,7 @@ dependencies {
   testImplementation 'jakarta.ws.rs:jakarta.ws.rs-api:3.1.0'
   testImplementation 'javax.ws.rs:javax.ws.rs-api:2.1.1'
   testImplementation 'javax.validation:validation-api:2.0.1.Final'
+
+  testImplementation 'org.projectlombok:lombok:1.18.26'
+  testAnnotationProcessor 'org.projectlombok:lombok:1.18.26'
 }

--- a/processor/src/main/java/net/orekyuu/nilou/UriBuilderAnnotationProcessor.java
+++ b/processor/src/main/java/net/orekyuu/nilou/UriBuilderAnnotationProcessor.java
@@ -6,6 +6,7 @@ import net.orekyuu.nilou.reverserouter.Endpoints;
 
 import javax.annotation.processing.AbstractProcessor;
 import javax.annotation.processing.RoundEnvironment;
+import javax.lang.model.SourceVersion;
 import javax.lang.model.element.Element;
 import javax.lang.model.element.TypeElement;
 import java.io.IOException;
@@ -24,7 +25,7 @@ public class UriBuilderAnnotationProcessor extends AbstractProcessor {
       }
     }
 
-    if (roundEnv.getRootElements().isEmpty()) {
+    if (roundEnv.processingOver()) {
       try {
         endpoints.endpointsFile().writeTo(processingEnv.getFiler());
       } catch (IOException e) {
@@ -37,6 +38,11 @@ public class UriBuilderAnnotationProcessor extends AbstractProcessor {
 
   @Override
   public Set<String> getSupportedAnnotationTypes() {
-    return Set.of("*");
+    return Set.of(UriBuilder.class.getCanonicalName());
+  }
+
+  @Override
+  public SourceVersion getSupportedSourceVersion() {
+    return SourceVersion.RELEASE_17;
   }
 }

--- a/processor/src/test/java/net/orekyuu/nilou/integration/JaxrsIntegrationTest.java
+++ b/processor/src/test/java/net/orekyuu/nilou/integration/JaxrsIntegrationTest.java
@@ -20,4 +20,9 @@ public class JaxrsIntegrationTest extends AnnotationProcessorTesting {
   void exampleControllers() {
     compile("exampleControllers");
   }
+
+  @Test
+  void withLombok() {
+    compileWithLombok("withLombok");
+  }
 }

--- a/processor/src/test/resources/withLombok/actual/test/HogeController.java
+++ b/processor/src/test/resources/withLombok/actual/test/HogeController.java
@@ -1,0 +1,22 @@
+package test;
+import lombok.RequiredArgsConstructor;
+import net.orekyuu.nilou.UriBuilder;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@Path("/hoge")
+@UriBuilder
+@RequiredArgsConstructor
+public class HogeController {
+
+  final String hoge;
+
+  @Path("")
+  @GET
+  public void all() {}
+
+  @Path("{id}")
+  @GET
+  public void get(@PathParam("id") String id) {}
+}

--- a/processor/src/test/resources/withLombok/expected/net/orekyuu/nilou/Endpoints.java
+++ b/processor/src/test/resources/withLombok/expected/net/orekyuu/nilou/Endpoints.java
@@ -1,0 +1,21 @@
+package net.orekyuu.nilou;
+
+import java.lang.String;
+import java.util.List;
+
+public final class Endpoints {
+    public static final class HogeController {
+        public static EndpointUriBuilder all() {
+            List<PathSegment> segments = List.of(PathSegment.ofLiteral("hoge"));
+            EndpointUriBuilder builder = new DefaultEndpointUriBuilder(segments);
+            return builder;
+        }
+
+        public static EndpointUriBuilder get(String id) {
+            List<PathSegment> segments = List.of(PathSegment.ofLiteral("hoge"), PathSegment.ofVariable("{id}", "id"));
+            EndpointUriBuilder builder = new DefaultEndpointUriBuilder(segments);
+            builder.pathParam("id", id);
+            return builder;
+        }
+    }
+}


### PR DESCRIPTION
注釈処理が最後のラウンドであることを確かめるにはprocessingOverを使うのが正しい。
各ラウンドの情報は `-XprintRounds` オプションを入れることで確かめられる。